### PR TITLE
Add a CloudFormation template for running in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ This is an AWS Lambda Node.js script which checks whether the HMPPS job feed par
 | `TASK_FAMILY` | Name of the task definition family to look for |
 | `TZ` | The timezone Node.js should run in, e.g. `Europe/London` |
 
-## Running in AWS Lambda
-
-Lambda should use the handler defined at `exports.handler`.
-
-As per the requirements, this should be run in the Node.js 8.10 runtime.
-
 ## Running locally
 
 This script can also be run locally:
@@ -46,3 +40,63 @@ This script can also be run locally:
    ```
    npm start
    ```
+   
+## Running in AWS
+
+A CloudFormation template [`cloudformation-template.yaml`](cloudformation-template.yaml) exists to get this script running on AWS. It will configure the infrastructure required to run this script automatically every night at 12:30am.
+
+### Create a CloudFormation stack
+
+Create a CloudFormation stack using the following steps.
+
+1. Create a ZIP file containing the Lambda function.
+   
+   In a terminal window, navigate to this git repository and run the following command:
+   
+   ```
+   zip index-$(md5 -q index.js | cut -c1-6).js.zip index.js
+   ```
+   
+   This will create a file called `index-XXXXXX.js.zip` which contains the `index.js` Lambda script.
+   
+   **Note:** The filename contains a partial MD5 sum to make the ZIP filename unique. This will be useful when deploying future changes to the Lambda function ([more info](#update-a-cloudformation-stack)).
+2. Upload `index.js.zip` to an S3 bucket in the `eu-west-2` region. Take note of the bucket name and path of the uploaded file – these will become the `LambdaS3Bucket` and `LambdaS3Key` parameters for our CloudFormation stack.
+3. Using the [CloudFormation 'Create Stack' wizard](https://eu-west-2.console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/new), upload the CloudFormation template file `cloudformation-template.yaml` and click Next.
+4. Give your stack a name and complete the required parameters.
+   
+   For example:
+   
+   | Parameter | Example Value |
+   | --------- | ------------- |
+   | Stack Name | hmpps-job-feed-monitor-production |
+   | EcsCluster | production |
+   | LambdaS3Bucket | hmpps-job-feed-monitor-lambda |
+   | LambdaS3Key | index.js.zip |
+   | LogGroup | hmpps-job-feed-production |
+   | SlackWebhookUrl | https://hooks.slack.com/services/XXXXXXX |
+   | TaskFamily | hmpps-job-feed-production |
+5. On the final page of the wizard, you will be asked to acknowledge that the template may create IAM resources. Check the box to confirm this, and click Create.
+6. Once the stack has reached a status of `CREATE_COMPLETED`, remove the `index-XXXXXX.js.zip` file (created in Step 1) from the S3 bucket. It is no longer needed and is safe to delete.
+
+Once completed, the script will run once a night at 12:30 AM using the parameters you provided during stack creation.
+
+### Update a CloudFormation stack
+
+You can change the parameters associated with an existing CloudFormation stack using the 'Update Stack' action. This will allow you to change the environment variables passed to the Lambda function.
+
+To deploy changes to the Lambda function (`index.js` file in this repo), you'll need to upload a new ZIP file to an S3 bucket and update the `LambdaS3Bucket` and `LambdaS3Key` parameters accordingly.
+
+**Note:** The S3 filename/key _must change_ for CloudFormation to re-deploy the Lambda function. This is why it's recommended to include a hash in the filename (as shown in Step 1 above) to ensure it changes when the file is updated.
+
+### Delete a CloudFormation stack
+
+When you delete a CloudFormation stack, all associated AWS resources will also be removed. This includes the CloudWatch log group and associated log streams.
+
+### AWS Resources
+
+The CloudFormation template creates the following resources:
+
+* **Lambda Function** – the main script of this project, `index.js`
+* **IAM Role** – the Lambda script will execute under this Role, so it must have permission to access the necessary AWS resources
+* **Log Group** – this is where Lambda execution logs will be stored
+* **CloudWatch Rule** – this will execute the Lambda script on a schedule (nightly at 12:30 AM)

--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -1,0 +1,94 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+
+  EcsCluster:
+    Description: The ECS cluster which the Task should have run on
+    Type: String
+
+  LambdaS3Bucket:
+    Description: S3 bucket to find the Lambda function ZIP in
+    Type: String
+
+  LambdaS3Key:
+    Description: S3 object name of the Lambda function ZIP
+    Type: String
+
+  LogGroup:
+    Description: Name of the CloudWatch log group that ECS Task output is sent to
+    Type: String
+
+  SlackWebhookUrl:
+    Description: Incoming Webhook URL that Slack messages should be posted to
+    Type: String
+
+  TaskFamily:
+    Description: Name of the task definition family to look for
+    Type: String
+
+Resources:
+
+  # Lambda function
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Monitor the execution of the HMPPS Job Feed Parser, and post to Slack if it didn't run successfully.
+      Runtime: nodejs8.10
+      Timeout: 30
+      Handler: index.handler
+      Role: !GetAtt LambdaRole.Arn
+      Environment:
+        Variables:
+          ECS_CLUSTER: !Ref EcsCluster
+          LOG_GROUP: !Ref LogGroup
+          SLACK_WEBHOOK_URL: !Ref SlackWebhookUrl
+          TASK_FAMILY: !Ref TaskFamily
+          TZ: Europe/London
+      Code:
+        S3Bucket: !Ref LambdaS3Bucket
+        S3Key: !Ref LambdaS3Key
+
+  # IAM Role used by the Lambda function
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Effect: Allow
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*:log-stream:*'
+              - Action:
+                  - ecs:ListTasks
+                  - ecs:DescribeTasks
+                Effect: Allow
+                Resource: '*'
+
+  # Log Group which the Lambda function logs to
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${Lambda}'
+      RetentionInDays: 365
+
+  # Schedule to automatically execute the Lambda function
+  LambdaSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub 'Execute the Lambda function ${Lambda} once each night, approximately 30 minutes after the HMPPS Job Feed Parser should have executed.'
+      ScheduleExpression: cron(30 0 * * ? *)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt Lambda.Arn
+          Id: lambda-function


### PR DESCRIPTION
- `cloudformation-template.yaml` can be used to provision an instance of this script, configured to run nightly at 12:30 AM
- Updated README adds instructions for provisioning the CloudFormation stack